### PR TITLE
error fix: c74_max_object.h (l.773)

### DIFF
--- a/include/c74_max_object.h
+++ b/include/c74_max_object.h
@@ -770,7 +770,7 @@ namespace max {
 		@param	parsestr		A C-string, which will be parsed into an array of atoms to set the initial value.
 	*/
 	#define CLASS_ATTR_CATEGORY(c,attrname,flags,parsestr) \
-		CLASS_ATTR_ATTR_PARSE(c,attrname,"category", c74::max::gensym("symbol"),flags,str_tr(parsestr))
+		CLASS_ATTR_ATTR_PARSE(c,attrname,"category", c74::max::gensym("symbol"),flags,parsestr)
 
 
 	/**


### PR DESCRIPTION
`CLASS_ATTR_CATEGORY` definition was throwing error on compile due to undefined `str_tr` in the 5th arg of the parsing function. Removed (arg is now just `parsestr`, in keeping with other definitions), this seems to have eliminated the error.