### PR TITLE
const t_symbol* for highly-used function args

### DIFF
--- a/include/c74_jitter.h
+++ b/include/c74_jitter.h
@@ -266,11 +266,11 @@ namespace max {
     void max_jit_obex_jitob_set(void *x, void *jitob);
     void max_jit_obex_dumpout_set(void *x, void *outlet);
     void *max_jit_obex_dumpout_get(void *x);
-    void max_jit_obex_dumpout(void *x, t_symbol *s, short argc, t_atom *argv);
+    void max_jit_obex_dumpout(void *x, const t_symbol *s, short argc, const t_atom *argv);
     void *max_jit_obex_adornment_get(void *x, t_symbol *classname);
     t_jit_err max_jit_obex_addadornment(void *x,void *adornment);
-    void max_jit_obex_gimmeback(void *x, t_symbol *s, long ac, t_atom *av);
-    void max_jit_obex_gimmeback_dumpout(void *x, t_symbol *s, long ac, t_atom *av);
+    void max_jit_obex_gimmeback(void *x, const t_symbol *s, long ac, const t_atom *av);
+    void max_jit_obex_gimmeback_dumpout(void *x, const t_symbol *s, long ac, const t_atom *av);
     t_jit_err max_jit_obex_proxy_new(void *x, long c);
     long max_jit_obex_inletnumber_get(void *x);
     void max_jit_obex_inletnumber_set(void *x, long inletnumber);

--- a/include/c74_max_object.h
+++ b/include/c74_max_object.h
@@ -2287,7 +2287,7 @@ namespace max {
 		@return 		This function returns the error code #MAX_ERR_NONE if successful, 
 		 				or one of the other error codes defined in #e_max_errorcodes if unsuccessful.
 	*/
-	void object_obex_dumpout(void* x, t_symbol* s, long argc, t_atom* argv);
+	void object_obex_dumpout(void* x, const t_symbol* s, long argc, const t_atom* argv);
 
 
 	// DO NOT CALL THIS -- It is called automatically now from object_free() or freeobject() -- calling this will cause problems.

--- a/include/c74_max_proto.h
+++ b/include/c74_max_proto.h
@@ -54,7 +54,7 @@ namespace max {
         tables. See the source code for the coll object for an example of using a
         privately defined class.
     */
-    void *newinstance(t_symbol *s, short argc, t_atom *argv);
+    void *newinstance(const t_symbol *s, short argc, const t_atom *argv);
 
 
 	/**	Use the setup() function to initialize your class by informing Max of its size,
@@ -476,7 +476,7 @@ namespace max {
 						Also, do not send lists using outlet_anything() with list as
 						the selector argument. Use the outlet_list() function instead.
 	*/
-	void* outlet_anything(void* o, t_symbol* s, short ac, const t_atom* av);
+	void* outlet_anything(void* o, const t_symbol* s, short ac, const t_atom* av);
 
 
 	// clock functions


### PR DESCRIPTION
`outlet_anything()` and making its t_symbol* `const` was the primary reason for this PR. Casting everywhere in my code is poor form.

* I did a regex and there are hundreds of other function signatures in which their t_symbol* can also be `const`.
* All the globals like `_jit_sym_char` should be const.
* It is likely many `t_atom* argv` in function signatures can also be `const`